### PR TITLE
Fix: out-of-order frameV2 results

### DIFF
--- a/src/SpiAnalyzer.h
+++ b/src/SpiAnalyzer.h
@@ -1,4 +1,4 @@
-#ifndef SPI_ANALYZER_H
+﻿#ifndef SPI_ANALYZER_H
 #define SPI_ANALYZER_H
 
 #include <Analyzer.h>
@@ -25,7 +25,7 @@ class SpiAnalyzer : public Analyzer2
     void AdvanceToActiveEnableEdge();
     bool IsInitialClockPolarityCorrect();
     void AdvanceToActiveEnableEdgeWithCorrectClockPolarity();
-    bool WouldAdvancingTheClockToggleEnable();
+    bool WouldAdvancingTheClockToggleEnable( bool add_disable_frame, U64* disable_frame );
     void GetWord();
 
 #pragma warning( push )


### PR DESCRIPTION
Fix a bug where the disable event would get ordered before the last word of a transaction if the next transaction had the clock and enable signal toggle at the same time. Example:

![image](https://user-images.githubusercontent.com/1790201/104499311-c3e33b80-5591-11eb-863b-9d591898537c.png)
