### PR TITLE
useframev2

### DIFF
--- a/src/SpiAnalyzer.cpp
+++ b/src/SpiAnalyzer.cpp
@@ -17,6 +17,7 @@ SpiAnalyzer::SpiAnalyzer()
       mEnable( NULL )
 {
     SetAnalyzerSettings( mSettings.get() );
+    UseFrameV2();
 }
 
 SpiAnalyzer::~SpiAnalyzer()


### PR DESCRIPTION
This won't build until the new UseFrameV2(); Function has become an official part of the SDK. In the meantime, do not use `UseFrameV2();`, as it will fail to build.